### PR TITLE
Centralize HTTP client and migrate service modules to service-specific request helpers

### DIFF
--- a/src/components/accounting/accounting.client.ts
+++ b/src/components/accounting/accounting.client.ts
@@ -1,14 +1,12 @@
-import { getErpServiceOrigin } from "@components/application/application.host.ts";
+import { erpServiceGet } from "@components/application/application.client.ts";
 import { accountingDashboardSummaryResponseSchema, type AccountingDashboardSummaryResponseData } from "./accounting.schema.ts";
-
-const root = getErpServiceOrigin();
 
 /**
  * Fetches accounting dashboard summary metrics from the accounting module API.
  */
 export const getAccountingDashboardSummary = async (): Promise<AccountingDashboardSummaryResponseData> => {
-  const response = await fetch(`${root}/accounting/dashboard/summary`, {
-    credentials: `include`,
+  const response = await erpServiceGet({
+    path: `/accounting/dashboard/summary`,
   });
 
   if (!response.ok) {

--- a/src/components/accountingConfiguration/accountingConfiguration.client.ts
+++ b/src/components/accountingConfiguration/accountingConfiguration.client.ts
@@ -1,17 +1,15 @@
-import { getErpServiceOrigin } from "@components/application/application.host.ts";
+import { erpServiceGet } from "@components/application/application.client.ts";
 import {
   accountingConfigurationResponseSchema,
   type AccountingConfigurationResponseData,
 } from "./accountingConfiguration.schema.ts";
 
-const root = getErpServiceOrigin();
-
 /**
  * Fetches accounting configuration.
  */
 export const getAccountingConfiguration = async (): Promise<AccountingConfigurationResponseData> => {
-  const response = await fetch(`${root}/accounting/configuration`, {
-    credentials: `include`,
+  const response = await erpServiceGet({
+    path: `/accounting/configuration`,
   });
 
   if (!response.ok) {

--- a/src/components/application/application.client.ts
+++ b/src/components/application/application.client.ts
@@ -1,0 +1,76 @@
+import { getAuthenticationServiceOrigin, getCoreServiceOrigin, getErpServiceOrigin } from "@components/application/application.host.ts";
+
+type ApplicationMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+
+type ApplicationRequestOptions = Omit<RequestInit, "body" | "method"> & {
+  origin?: string;
+  path: string;
+};
+
+type ApplicationBodyRequestOptions<TBody> = ApplicationRequestOptions & {
+  body: TBody;
+};
+
+export const applicationFetch = ({ body, origin, path, ...init }: ApplicationRequestOptions & { body?: unknown }) => {
+  const url = origin ? `${origin}${path}` : path;
+
+  return fetch(url, {
+    ...init,
+    body: body === undefined ? undefined : JSON.stringify(body),
+    credentials: init.credentials ?? `include`,
+    headers: {
+      ...(body === undefined ? {} : { "Content-Type": `application/json` }),
+      ...init.headers,
+    },
+  });
+};
+
+const createServiceMethod = (method: ApplicationMethod) => {
+  return <TBody = never>(options: ApplicationRequestOptions | ApplicationBodyRequestOptions<TBody>) => {
+    return applicationFetch({
+      ...options,
+      method,
+    });
+  };
+};
+
+const createServiceRequest = (getDefaultOrigin: () => string) => {
+  return (method: ApplicationMethod) => {
+    const request = createServiceMethod(method);
+
+    return <TBody = never>(options: ApplicationRequestOptions | ApplicationBodyRequestOptions<TBody>) => {
+      return request({
+        ...options,
+        origin: options.origin ?? getDefaultOrigin(),
+      });
+    };
+  };
+};
+
+export const appGet = createServiceMethod("GET");
+export const appDelete = createServiceMethod("DELETE");
+export const appPost = createServiceMethod("POST");
+export const appPatch = createServiceMethod("PATCH");
+export const appPut = createServiceMethod("PUT");
+
+const coreServiceMethod = createServiceRequest(getCoreServiceOrigin);
+const authenticationServiceMethod = createServiceRequest(getAuthenticationServiceOrigin);
+const erpServiceMethod = createServiceRequest(getErpServiceOrigin);
+
+export const coreServiceGet = coreServiceMethod("GET");
+export const coreServiceDelete = coreServiceMethod("DELETE");
+export const coreServicePost = coreServiceMethod("POST");
+export const coreServicePatch = coreServiceMethod("PATCH");
+export const coreServicePut = coreServiceMethod("PUT");
+
+export const authenticationServiceGet = authenticationServiceMethod("GET");
+export const authenticationServiceDelete = authenticationServiceMethod("DELETE");
+export const authenticationServicePost = authenticationServiceMethod("POST");
+export const authenticationServicePatch = authenticationServiceMethod("PATCH");
+export const authenticationServicePut = authenticationServiceMethod("PUT");
+
+export const erpServiceGet = erpServiceMethod("GET");
+export const erpServiceDelete = erpServiceMethod("DELETE");
+export const erpServicePost = erpServiceMethod("POST");
+export const erpServicePatch = erpServiceMethod("PATCH");
+export const erpServicePut = erpServiceMethod("PUT");

--- a/src/components/application/application.client.ts
+++ b/src/components/application/application.client.ts
@@ -2,7 +2,7 @@ import { getAuthenticationServiceOrigin, getCoreServiceOrigin, getErpServiceOrig
 
 type ApplicationMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
 
-type ApplicationRequestOptions = Omit<RequestInit, "body" | "method"> & {
+type ApplicationRequestOptions = Omit<RequestInit, "body"> & {
   origin?: string;
   path: string;
 };

--- a/src/components/application/application.config.ts
+++ b/src/components/application/application.config.ts
@@ -1,3 +1,4 @@
+import { applicationFetch } from "@components/application/application.client.ts";
 import type { AppConfig } from '@components/application/application.schema.ts';
 
 const defaultAppConfig: AppConfig = {
@@ -46,8 +47,10 @@ const parseAppConfig = (value: unknown): AppConfig => {
 export const loadAppConfig = async (): Promise<AppConfig> => {
   const loadConfigFromUrl = async (url: string): Promise<AppConfig | null> => {
     try {
-      const response = await fetch(url, {
+      const response = await applicationFetch({
         cache: `no-store`,
+        credentials: `same-origin`,
+        path: url,
       });
 
       if (!response.ok) {

--- a/src/components/application/application.query.ts
+++ b/src/components/application/application.query.ts
@@ -2,15 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { apiSuccessSchema } from '@components/application/api.schema.ts';
-import { getCoreServiceOrigin } from '@components/application/application.host.ts';
+import { coreServiceGet } from "@components/application/application.client.ts";
 
 /**
  * Probes whether the browser is running on the root Reados application host.
  */
 export const probeRootApplication = async () => {
   try {
-    const coreServiceOrigin = getCoreServiceOrigin();
-    const response = await fetch(`${coreServiceOrigin}/whoami`);
+    const response = await coreServiceGet({
+      path: `/whoami`,
+    });
 
     if (!response.ok) {
       return false;

--- a/src/components/authentication/authentication.client.ts
+++ b/src/components/authentication/authentication.client.ts
@@ -1,20 +1,14 @@
-import { getAuthenticationServiceOrigin } from '@components/application/application.host.ts';
+import { authenticationServiceGet, authenticationServicePatch, authenticationServicePost } from "@components/application/application.client.ts";
 import { otpRequestBodySchema, otpRequestResponseSchema, otpTestResponseSchema, otpVerifyBodySchema, otpVerifyResponseSchema, profileUpdateBodySchema, sessionMeResponseDataSchema, sessionMeResponseSchema } from './authentication.schema.ts';
-
-const root = getAuthenticationServiceOrigin();
 
 /**
  * Requests an OTP code for tenant-scoped authentication.
  */
 export const requestAuthenticationOtp = async (body: unknown) => {
   const parsedBody = otpRequestBodySchema.parse(body);
-  const response = await fetch(`${root}/otp/request`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      'Content-Type': `application/json`,
-    },
-    method: `POST`,
+  const response = await authenticationServicePost({
+    body: parsedBody,
+    path: `/otp/request`,
   });
 
   if (!response.ok) {
@@ -29,13 +23,9 @@ export const requestAuthenticationOtp = async (body: unknown) => {
  */
 export const verifyAuthenticationOtp = async (body: unknown) => {
   const parsedBody = otpVerifyBodySchema.parse(body);
-  const response = await fetch(`${root}/otp/verify`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      'Content-Type': `application/json`,
-    },
-    method: `POST`,
+  const response = await authenticationServicePost({
+    body: parsedBody,
+    path: `/otp/verify`,
   });
 
   if (!response.ok) {
@@ -49,8 +39,8 @@ export const verifyAuthenticationOtp = async (body: unknown) => {
  * Retrieves the authenticated session state.
  */
 export const getAuthenticationSession = async () => {
-  const response = await fetch(`${root}/session/me`, {
-    credentials: `include`,
+  const response = await authenticationServiceGet({
+    path: `/session/me`,
   });
 
   if (response.status === 401) {
@@ -71,9 +61,9 @@ export const getAuthenticationSession = async () => {
  * Logs out the current authenticated session.
  */
 export const logoutAuthenticationSession = async () => {
-  await fetch(`${root}/session/logout`, {
-    credentials: `include`,
-    method: `POST`,
+  await authenticationServicePost({
+    body: {},
+    path: `/session/logout`,
   });
 };
 
@@ -82,13 +72,9 @@ export const logoutAuthenticationSession = async () => {
  */
 export const updateAuthenticationProfile = async (body: unknown) => {
   const parsedBody = profileUpdateBodySchema.parse(body);
-  const response = await fetch(`${root}/profile/me`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      'Content-Type': `application/json`,
-    },
-    method: `PATCH`,
+  const response = await authenticationServicePatch({
+    body: parsedBody,
+    path: `/profile/me`,
   });
 
   if (!response.ok) {
@@ -102,8 +88,8 @@ export const updateAuthenticationProfile = async (body: unknown) => {
  * Reads the latest OTP for e2e tests from the test-only transport endpoint.
  */
 export const getLatestOtpForTesting = async ({ email }: { email: string }) => {
-  const response = await fetch(`${root}/test/otp/latest?email=${encodeURIComponent(email)}`, {
-    credentials: `include`,
+  const response = await authenticationServiceGet({
+    path: `/test/otp/latest?email=${encodeURIComponent(email)}`,
   });
 
   if (!response.ok) {

--- a/src/components/segment/segment.client.ts
+++ b/src/components/segment/segment.client.ts
@@ -1,4 +1,4 @@
-import { getErpServiceOrigin } from "@components/application/application.host.ts";
+import { erpServiceDelete, erpServiceGet, erpServicePatch, erpServicePost } from "@components/application/application.client.ts";
 
 import {
   segmentListResponseSchema,
@@ -12,14 +12,12 @@ import {
   updateSegmentBodySchema,
 } from "./segment.schema.ts";
 
-const root = getErpServiceOrigin();
-
 /**
  * Fetches all accounting segments.
  */
 export const getSegments = async (): Promise<Segment[]> => {
-  const response = await fetch(`${root}/accounting/segment`, {
-    credentials: `include`,
+  const response = await erpServiceGet({
+    path: `/accounting/segment`,
   });
 
   if (!response.ok) {
@@ -34,13 +32,9 @@ export const getSegments = async (): Promise<Segment[]> => {
  */
 export const createSegment = async (body: CreateSegmentBody): Promise<Segment> => {
   const parsedBody = createSegmentBodySchema.parse(body);
-  const response = await fetch(`${root}/accounting/segment`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      "Content-Type": `application/json`,
-    },
-    method: `POST`,
+  const response = await erpServicePost({
+    body: parsedBody,
+    path: `/accounting/segment`,
   });
 
   if (!response.ok) {
@@ -55,13 +49,9 @@ export const createSegment = async (body: CreateSegmentBody): Promise<Segment> =
  */
 export const updateSegment = async (id: string, body: UpdateSegmentBody): Promise<Segment> => {
   const parsedBody = updateSegmentBodySchema.parse(body);
-  const response = await fetch(`${root}/accounting/segment/${encodeURIComponent(id)}`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      "Content-Type": `application/json`,
-    },
-    method: `PATCH`,
+  const response = await erpServicePatch({
+    body: parsedBody,
+    path: `/accounting/segment/${encodeURIComponent(id)}`,
   });
 
   if (!response.ok) {
@@ -76,13 +66,9 @@ export const updateSegment = async (id: string, body: UpdateSegmentBody): Promis
  */
 export const reorderSegment = async (id: string, body: ReorderSegmentBody): Promise<Segment> => {
   const parsedBody = reorderSegmentBodySchema.parse(body);
-  const response = await fetch(`${root}/accounting/segment/${encodeURIComponent(id)}/reorder`, {
-    body: JSON.stringify(parsedBody),
-    credentials: `include`,
-    headers: {
-      "Content-Type": `application/json`,
-    },
-    method: `POST`,
+  const response = await erpServicePost({
+    body: parsedBody,
+    path: `/accounting/segment/${encodeURIComponent(id)}/reorder`,
   });
 
   if (!response.ok) {
@@ -96,9 +82,8 @@ export const reorderSegment = async (id: string, body: ReorderSegmentBody): Prom
  * Deletes one accounting segment.
  */
 export const deleteSegment = async (id: string): Promise<Segment> => {
-  const response = await fetch(`${root}/accounting/segment/${encodeURIComponent(id)}`, {
-    credentials: `include`,
-    method: `DELETE`,
+  const response = await erpServiceDelete({
+    path: `/accounting/segment/${encodeURIComponent(id)}`,
   });
 
   if (!response.ok) {

--- a/src/components/tenant/tenant.client.ts
+++ b/src/components/tenant/tenant.client.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { getBrowserProtocol } from '@components/application/application.browser.ts';
+import { applicationFetch } from "@components/application/application.client.ts";
 import { getAppConfig } from '@components/application/application.config.ts';
 import { tenantDiscoveryRequestSchema, tenantDiscoveryResponseSchema, type TenantDiscoveryRequest, type TenantDiscoveryResponseData } from './tenant.schema.ts';
 
@@ -19,11 +20,11 @@ const getRoot = () => {
  */
 export const discoverTenants = async (body: TenantDiscoveryRequest): Promise<TenantDiscoveryResponseData> => {
   const parsedBody = tenantDiscoveryRequestSchema.parse(body);
-  const response = await fetch(`${getRoot()}/discovery`, {
-    body: JSON.stringify(parsedBody),
-    headers: {
-      'Content-Type': `application/json`,
-    },
+  const response = await applicationFetch({
+    body: parsedBody,
+    credentials: `same-origin`,
+    origin: getRoot(),
+    path: `/discovery`,
     method: `POST`,
   });
 


### PR DESCRIPTION
### Motivation

- Provide a single, consistent HTTP abstraction for the app to centralize origin handling, body serialization, credentials, and method helpers.
- Replace ad-hoc `fetch` + origin lookup patterns across service clients with typed, service-specific request functions to reduce duplication and mistakes.

### Description

- Added `src/components/application/application.client.ts` that exports `applicationFetch`, generic `app*` helpers and service-specific factory helpers such as `coreServiceGet`, `authenticationServicePost`, and `erpServiceGet` which default the request origin and common options.
- Migrated multiple modules to use the new helpers instead of manual `fetch` and `get*ServiceOrigin` calls, including `authentication.client.ts`, `accounting.client.ts`, `accountingConfiguration.client.ts`, `segment.client.ts`, `tenant.client.ts`, and `application.query.ts`.
- Updated `application.config.ts` to load config via `applicationFetch` and adjusted credentials to `same-origin` for config fetches while the global fetch helper defaults to `include` and JSON serialization for bodies.
- Simplified request bodies and headers by passing parsed objects to the helper functions (the helper serializes to JSON and sets `Content-Type` when a body is present).

### Testing

- Ran TypeScript type-check and compilation checks and they completed successfully.
- Ran the repository's automated unit tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1528886a308333a81a6ed30cbdda83)